### PR TITLE
Added config field for specifying a simulator host

### DIFF
--- a/HALs/sim_HAL.py
+++ b/HALs/sim_HAL.py
@@ -24,21 +24,24 @@ class sim_HAL(HAL_base):
 
     motorCount = 4
     
+    host: str = None
+
     client = None
     sim = None
     mtr = None
     sensorHandle = None
     
-    def __init__(self):
+    def __init__(self, host: str):
         super().__init__()
         self.lock = threading.Lock()
+        self.host = host
 
     def start_arm(self):
 
         if self.sim is None:
             with self.lock:
                 # remote API init
-                self.client = RemoteAPIClient()
+                self.client = RemoteAPIClient(host=self.host)
                 self.sim = self.client.require('sim')
                 
                 # motor ids

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ config = {
     "config_version" : 1,
     "use_simulator" : True,
     "use_physical" : False,
+    "sim_host": "localhost",
     "use_app" : False,
     "use_server" : True,
     "use_twitch" : False,
@@ -127,7 +128,7 @@ selected_HAL : HAL_base = None
 
 if config["use_simulator"]:
     from HALs.sim_HAL import sim_HAL
-    selected_HAL = sim_HAL()
+    selected_HAL = sim_HAL(config["sim_host"])
 elif config["use_physical"]:
     from HALs.physical_HAL import physical_HAL
     selected_HAL = physical_HAL()

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ import sys
 # these are the default values, they are saved in a file called config.json that is ignored by git.
 # if you add or rename parameters, please increment config_version for everything to work properly. 
 config = {
-    "config_version" : 1,
+    "config_version" : 2,
     "use_simulator" : True,
     "use_physical" : False,
     "sim_host": "localhost",


### PR DESCRIPTION
This allows for the simulator to run on a host other than localhost relative to the arm program. Currently the main use case of this is connecting to Windows sim from within WSL.