### PR TITLE
Added a prompt to install ollama if it is not already installed.

### DIFF
--- a/Modules/Language/LanguageInterpreter.py
+++ b/Modules/Language/LanguageInterpreter.py
@@ -3,6 +3,8 @@ import ollama._types
 from inspect import signature, Parameter
 from typing import Callable
 import os.path
+import httpcore
+from OLLAMA_installer import install_ollama, prompt_user
 
 def tool(description: str, **parameter_descriptions):
     def tool_decorator(func: Callable):
@@ -49,7 +51,17 @@ class LanguageInterpreter:
             with open(model_file_path, "w") as f:
                 f.write(DEFAULT_MODEL_FILE)
         last_status_line = ""
-        for info in ollama.create("arm_model", path=model_file_path, stream=True):
+        
+        ollama_infos = None
+        try:
+            ollama_infos = ollama.create("arm_model", path=model_file_path, stream=True)
+        except httpcore.ConnectError as ex:
+            print("Error loading arm language model: " + repr(ex))
+            if prompt_user("Ollama is not installed. Would you like to install it?"):
+                install_ollama()
+                ollama_infos = ollama.create("arm_model", path=model_file_path, stream=True)
+            
+        for info in ollama_infos:
             status_line = f"Loading arm language model from '{model_file_path}': " + info["status"]
             if "total" in info and "completed" in info:
                 status_line += " (" + str(info["total"]) + " / " + str(info["completed"]) + ")"

--- a/Modules/Language/OLLAMA_installer.py
+++ b/Modules/Language/OLLAMA_installer.py
@@ -1,0 +1,58 @@
+import subprocess
+import platform
+
+def install_ollama():
+    os_type = platform.system()
+    
+    if os_type == 'Windows':
+        # Use the winget command to install Ollama on Windows
+        command = "winget install Ollama.Ollama"
+    elif os_type == 'Darwin':  # macOS
+        # Use the brew command to install Ollama on macOS
+        command = "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\" && brew install ollama"
+    elif os_type == 'Linux':
+        # Use the appropriate package manager for Linux
+        distro = platform.linux_distribution()[0].lower()
+        if 'ubuntu' in distro or 'debian' in distro:
+            command = "sudo apt-get update && sudo apt-get install -y ollama"
+        elif 'fedora' in distro or 'centos' in distro:
+            command = "sudo dnf install -y ollama"
+        elif 'arch' in distro:
+            command = "sudo pacman -S ollama"
+        else:
+            raise Exception("Unsupported Linux distribution")
+    else:
+        raise Exception("Unsupported Operating System")
+    
+    try:
+        subprocess.run(command, shell=True, check=True)
+        print("Ollama installation successful.")
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to install Ollama: {e}")
+
+def prompt_user(question):
+    # Define acceptable responses for yes and no
+    yes_responses = {'yes', 'y', 'Y', 'accept', 'ok', 'sure', 'affirmative', 'yeah', 'yep'}
+    no_responses = {'no', 'n', 'N', 'reject', 'nope', 'negative'}
+
+    while True:
+        # Prompt the user
+        response = input(f"{question} (yes/no): ").strip().lower()
+
+        # Check if the response is in the acceptable yes responses
+        if response in yes_responses:
+            return True
+        # Check if the response is in the acceptable no responses
+        elif response in no_responses:
+            return False
+        else:
+            print("Answer not accepted. Please respond with yes or no.")
+
+if __name__ == "__main__":
+    # Example usage
+    answer = prompt_user("Do you want to continue?")
+    if answer:
+        print("You chose to continue.")
+    else:
+        print("You chose not to continue.")
+

--- a/requirments.txt
+++ b/requirments.txt
@@ -59,3 +59,4 @@ vosk
 pyaudio
 pyttsx3
 pynput
+httpcore


### PR DESCRIPTION
This PR adds a way to install ollama (the program that hosts the LLMs) automatically if it is not detected.

TO TEST:

Run the main on a system that does not have Ollama installed, and it should have a prompt in the console window to ask if you want to install it, say yes and it will install ollama then perform a normal startup.